### PR TITLE
fix for test purpose

### DIFF
--- a/hapi-plugin-co.js
+++ b/hapi-plugin-co.js
@@ -33,7 +33,7 @@ var Package = require("./package.json")
 var register = function (server, options, next) {
 
     /*  perform WebSocket handling on HAPI start  */
-    server.ext({ type: "onPostStart", method: function (server, next) {
+    server.ext({ type: "onPreStart", method: function (server, next) {
 
         /*  iterate over all routes  */
         var connections = server.table()

--- a/hapi-plugin-co.js
+++ b/hapi-plugin-co.js
@@ -68,6 +68,9 @@ var register = function (server, options, next) {
                                         request.log([ "error", "uncaught" ], String(err))
                                     }
                                 }
+                                if (err.data && typeof err.data === "object") {
+                                  Object.assign(err.output.payload, err.data);
+                                }
                                 reply(err)
                             })
                         }
@@ -89,4 +92,3 @@ register.attributes = { pkg: Package }
 
 /*  export register function, wrapped in a plugin object  */
 module.exports = { register: register }
-


### PR DESCRIPTION
To be able to use `server.inject` without actually starting the server, the plugin need to wrap all the handlers `onPreStart` hook.

I'll try to add some test this week at least next week :)
