### PR TITLE
wrap Boom around an error to keep the stack

### DIFF
--- a/hapi-plugin-co.js
+++ b/hapi-plugin-co.js
@@ -56,7 +56,7 @@ var register = function (server, options, next) {
                                 /*  convert errors into HTTP replies  */
                                 if (!(typeof err === "object" && err.isBoom)) {
                                     if (err instanceof Error) {
-                                        err = Boom.create(500, err.message)
+                                        err = Boom.wrap(err, 500)
                                         request.log([ "error", "uncaught" ], err.message)
                                     }
                                     else if (typeof err === "string") {


### PR DESCRIPTION
wrapping the error instead of creating a new Boom hopefully keeps the original error stack and prints it on error

currently Booming an Error swallows the stack
