### PR TITLE
Fix for calling reply interface more than once

### DIFF
--- a/hapi-plugin-co.js
+++ b/hapi-plugin-co.js
@@ -50,8 +50,9 @@ var register = function (server, options, next) {
                             /*  execute generator function as a co-routine  */
                             co.wrap(handler.bind(this))(request, reply).then(function (result) {
                                 /*  convert return values into HTTP replies  */
-                                if (result !== undefined)
-                                    reply(result)
+                                if (result !== undefined) {
+                                    return result
+                                }
                             }).catch(function (err) {
                                 /*  convert errors into HTTP replies  */
                                 if (!(typeof err === "object" && err.isBoom)) {
@@ -68,7 +69,7 @@ var register = function (server, options, next) {
                                         err = Boom.create(500, String(err))
                                     }
                                 }
-                                reply(err)
+                                return err
                             })
                         }
                     })(route.settings.handler)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":        "hapi-plugin-co",
-    "version":     "0.9.4",
+    "version":     "0.9.5",
     "description": "HAPI plugin for Co-Routine handlers",
     "keywords":    [ "hapi", "plugin", "co", "handler" ],
     "main":        "./hapi-plugin-co.js",


### PR DESCRIPTION
Seeing a lot of this in the console:

>(node:74656) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: reply interface called twice

This fix addresses it so reply is only called at the higher interface